### PR TITLE
parseNode could parse ptr too

### DIFF
--- a/nested_set.go
+++ b/nested_set.go
@@ -52,8 +52,8 @@ func parseNode(db *gorm.DB, source interface{}) (tx *gorm.DB, item nodeItem, err
 	}
 
 	item = nodeItem{TableName: stmt.Table, DbNames: map[string]string{}}
-	sourceType := reflect.TypeOf(source)
 	sourceValue := reflect.Indirect(reflect.ValueOf(source))
+	sourceType := sourceValue.Type()
 	for i := 0; i < sourceType.NumField(); i++ {
 		t := sourceType.Field(i)
 		v := sourceValue.Field(i)

--- a/nested_set_test.go
+++ b/nested_set_test.go
@@ -36,6 +36,19 @@ func TestNewNodeItem(t *testing.T) {
 	stmt.Build(clause.Where{}.Name())
 	assert.Equal(t, "WHERE user_id = $1 AND user_type = $2", stmt.SQL.String())
 
+	tx, node, err = parseNode(db, &source)
+	assert.NoError(t, err)
+	assert.Equal(t, source.ID, node.ID)
+	assert.Equal(t, source.ParentID, node.ParentID)
+	assert.Equal(t, source.Depth, node.Depth)
+	assert.Equal(t, source.Lft, node.Lft)
+	assert.Equal(t, source.Rgt, node.Rgt)
+	assert.Equal(t, source.ChildrenCount, node.ChildrenCount)
+	assert.Equal(t, "categories", node.TableName)
+	stmt = tx.Statement
+	stmt.Build(clause.Where{}.Name())
+	assert.Equal(t, "WHERE user_id = $1 AND user_type = $2", stmt.SQL.String())
+
 	dbNames := node.DbNames
 	assert.Equal(t, "id", dbNames["id"])
 	assert.Equal(t, "parent_id", dbNames["parent_id"])


### PR DESCRIPTION
This is an issue I meet when I try build node as this:
```golang
n0 := &Category{Title: "Stack", Lft: 1, Rgt: 2}
n00 := &Category{Title: "Language", Lft: 3, Rgt: 4}
n000 := &Category{Title: "Go", Lft: 5, Rgt: 6}

db.Create(n0)
db.Create(n00)
db.Create(n000)

tx := db.Model(&Category{})
nestedset.MoveTo(tx, n00, n0, nestedset.MoveDirectionInner)
```

and **WE DO NEED** to reload it again after **MoveTo**